### PR TITLE
[RENDER-2923] Update supported file versions

### DIFF
--- a/docs/guides/supported-file-formats.mdx
+++ b/docs/guides/supported-file-formats.mdx
@@ -14,7 +14,7 @@ Vertex supports the following file formats. We regularly add additional support.
 | IFC              | .ifc                                             | 2-4                        |
 | IGES             | .iges, .igs                                      | Up to 5.3                  |
 | Inventor         | .iam\*, .ipt                                     | Up to 2021                 |
-| JT               | .jt\*\*                                          | 8.0-10.3                   |
+| JT               | .jt\*\*                                          | 8.0-10.5                   |
 | NX - Unigraphics | .prt                                             | 11-12 and 1926             |
 | OBJ              | .obj                                             | All                        |
 | Parasolid        | .x_b, .x_t, .xmt, .xmt_txt                       | Up to 32                   |

--- a/versioned_docs/version-beta/guides/importing-data.md
+++ b/versioned_docs/version-beta/guides/importing-data.md
@@ -26,7 +26,7 @@ Support for new formats is added regularly.
 |       IFC        |                       .ifc                       |            2-4            |
 |       IGES       |                   .iges, .igs                    |         Up to 5.3         |
 |     Inventor     |                   .iam\*, .ipt                   |        Up to 2021         |
-|        JT        |                     .jt\*\*                      |         8.0-10.3          |
+|        JT        |                     .jt\*\*                      |         8.0-10.5          |
 | NX - Unigraphics |                       .prt                       |      11-12, and 1926      |
 |       OBJ        |                       .obj                       |            All            |
 |    Parasolid     |            .x_b, .x_t, .xmt, .xmt_txt            |         Up to 32          |


### PR DESCRIPTION
## Summary
We updated to the newest version of the hoops sdk, which supports JT files up to version 10.5.  Thus, updating the documentation accordingly.

## Test Plan
See documentation.

## Possible Regressions
Formatting

## Dependencies
None