### PR TITLE
Fixed issue with scrollbar displayed next to logo

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -442,6 +442,7 @@ p.lead-in {
 .navbar__logo {
   height: 26px;
   padding: 0 0.5rem;
+  overflow: hidden;
 }
 .navbar .navbar__brand img {
   max-width: none;


### PR DESCRIPTION
## Summary
Added a CSS improvement to prevent scrollbar from being shown next to logo. I'm not quite sure why the scrollbar began to show -- the heights did not seem to overflow. But this will prevent scrollbar from showing.

## Test Plan
I tested locally. This should be safe enough to just test after deployment.

## Release Notes
None

## Possible Regressions
N/A

## Dependencies
None
