### PR TITLE
[PLAT-2384] Revit 2023 Support

### DIFF
--- a/docs/guides/supported-file-formats.mdx
+++ b/docs/guides/supported-file-formats.mdx
@@ -19,7 +19,7 @@ Vertex supports the following file formats. We regularly add additional support.
 | NX - Unigraphics | .prt                                             | 11-12 and 1847-2206                              |
 | OBJ              | .obj                                             | All                                              |
 | Parasolid        | .x_b, .x_t, .xmt, .xmt_txt                       | Up to 34.1                                       |
-| Revit            | .rvt, .rfa                                       | 2015-2022                                        |
+| Revit            | .rvt, .rfa                                       | 2015-2023                                        |
 | Rhino            | .3dm                                             | 4-7                                              |
 | Solid Edge       | .asm\*, .par                                     | 19-20, ST1-ST10, and 2021-2022                   |
 | SolidWorks       | .sldasm\*, .sldprt                               | 97-2022                                          |

--- a/versioned_docs/version-beta/guides/importing-data.md
+++ b/versioned_docs/version-beta/guides/importing-data.md
@@ -31,7 +31,7 @@ Support for new formats is added regularly.
 | NX - Unigraphics |                       .prt                       |               11-12, and 1847-2206               |
 |       OBJ        |                       .obj                       |                       All                        |
 |    Parasolid     |            .x_b, .x_t, .xmt, .xmt_txt            |                    Up to 34.1                    |
-|      Revit       |                       .rvt                       |                    2015-2022                     |
+|      Revit       |                       .rvt                       |                    2015-2023                     |
 |    Solid Edge    |                   .asm\*, .par                   |          19-20, ST1-ST10, and 2021-2022          |
 |    SolidWorks    |                .sldasm\*, .sldprt                |                     97-2022                      |
 |       STEP       |                   .step, .stp                    |               AP203, AP214, AP242                |


### PR DESCRIPTION
## Summary
We now support Revit 2023 and this updates the documentation accordingly.