### PR TITLE
[PLAT-2883] Update supported file formats

### DIFF
--- a/docs/guides/supported-file-formats.mdx
+++ b/docs/guides/supported-file-formats.mdx
@@ -18,7 +18,7 @@ Vertex supports the following file formats. We regularly add additional support.
 | JT               | .jt\*\*                                          | 8.0-10.6                                         |
 | NX - Unigraphics | .prt                                             | 11-12 and 1847-2212                              |
 | OBJ              | .obj                                             | All                                              |
-| Parasolid        | .x_b, .x_t, .xmt, .xmt_txt                       | Up to 35.0                                       |
+| Parasolid        | .x_b, .x_t, .xmt, .xmt_txt                       | Up to 35.1                                       |
 | Revit            | .rvt, .rfa                                       | 2015-2023                                        |
 | Rhino            | .3dm                                             | 4-7                                              |
 | Solid Edge       | .asm\*, .par                                     | 19-20, ST1-ST10, and 2021-2023                   |

--- a/versioned_docs/version-beta/guides/importing-data.md
+++ b/versioned_docs/version-beta/guides/importing-data.md
@@ -30,7 +30,7 @@ Support for new formats is added regularly.
 |        JT        |                     .jt\*\*                      |                     8.0-10.6                     |
 | NX - Unigraphics |                       .prt                       |               11-12, and 1847-2212               |
 |       OBJ        |                       .obj                       |                       All                        |
-|    Parasolid     |            .x_b, .x_t, .xmt, .xmt_txt            |                    Up to 35.0                    |
+|    Parasolid     |            .x_b, .x_t, .xmt, .xmt_txt            |                    Up to 35.1                    |
 |      Revit       |                       .rvt                       |                    2015-2023                     |
 |    Solid Edge    |                   .asm\*, .par                   |          19-20, ST1-ST10, and 2021-2023          |
 |    SolidWorks    |                .sldasm\*, .sldprt                |                     97-2023                      |


### PR DESCRIPTION
## Summary
We now support Parasolid 35.1 and this updates the documentation accordingly.