### PR TITLE
[PLAT-3066] Update supported file formats

### DIFF
--- a/docs/guides/supported-file-formats.mdx
+++ b/docs/guides/supported-file-formats.mdx
@@ -14,7 +14,7 @@ Vertex supports the following file formats. We regularly add additional support.
 | Creo View        | .pvz, .ol                                        | Creo View Express 4-7 and Creo View ECAD 6.1.0.0 |
 | IFC              | .ifc                                             | 2-4                                              |
 | IGES             | .iges, .igs                                      | Up to 5.3                                        |
-| Inventor         | .iam\*, .ipt                                     | Up to 2023                                       |
+| Inventor         | .iam\*, .ipt                                     | Up to 2024                                       |
 | JT               | .jt\*\*                                          | 8.0-10.6                                         |
 | NX - Unigraphics | .prt                                             | 11-12 and 1847-2212                              |
 | OBJ              | .obj                                             | All                                              |

--- a/versioned_docs/version-beta/guides/importing-data.md
+++ b/versioned_docs/version-beta/guides/importing-data.md
@@ -26,7 +26,7 @@ Support for new formats is added regularly.
 |    Creo View     |                    .pvz, .ol                     | Creo View Express 4-7 and Creo View ECAD 6.1.0.0 |
 |       IFC        |                       .ifc                       |                       2-4                        |
 |       IGES       |                   .iges, .igs                    |                    Up to 5.3                     |
-|     Inventor     |                   .iam\*, .ipt                   |                    Up to 2023                    |
+|     Inventor     |                   .iam\*, .ipt                   |                    Up to 2024                    |
 |        JT        |                     .jt\*\*                      |                     8.0-10.6                     |
 | NX - Unigraphics |                       .prt                       |               11-12, and 1847-2212               |
 |       OBJ        |                       .obj                       |                       All                        |


### PR DESCRIPTION
## Summary
We now support Inventor 2024 and this updates the documentation accordingly.