### PR TITLE
Revert "[PLAT-3398] Update supported file formats"

### DIFF
--- a/docs/guides/supported-file-formats.mdx
+++ b/docs/guides/supported-file-formats.mdx
@@ -15,8 +15,8 @@ Vertex supports the following file formats. We regularly add additional support.
 | IFC              | .ifc                                             | 2-4                                              |
 | IGES             | .iges, .igs                                      | Up to 5.3                                        |
 | Inventor         | .iam\*, .ipt                                     | Up to 2024                                       |
-| JT               | .jt\*\*                                          | 8.0-10.9                                         |
-| NX - Unigraphics | .prt                                             | 11-12 and 1847-2306                              |
+| JT               | .jt\*\*                                          | 8.0-10.6                                         |
+| NX - Unigraphics | .prt                                             | 11-12 and 1847-2212                              |
 | OBJ              | .obj                                             | All                                              |
 | Parasolid        | .x_b, .x_t, .xmt, .xmt_txt                       | Up to 35.1                                       |
 | Revit            | .rvt, .rfa                                       | 2015-2023                                        |

--- a/versioned_docs/version-beta/guides/importing-data.md
+++ b/versioned_docs/version-beta/guides/importing-data.md
@@ -27,8 +27,8 @@ Support for new formats is added regularly.
 |       IFC        |                       .ifc                       |                       2-4                        |
 |       IGES       |                   .iges, .igs                    |                    Up to 5.3                     |
 |     Inventor     |                   .iam\*, .ipt                   |                    Up to 2024                    |
-|        JT        |                     .jt\*\*                      |                     8.0-10.9                     |
-| NX - Unigraphics |                       .prt                       |               11-12, and 1847-2306               |
+|        JT        |                     .jt\*\*                      |                     8.0-10.6                     |
+| NX - Unigraphics |                       .prt                       |               11-12, and 1847-2212               |
 |       OBJ        |                       .obj                       |                       All                        |
 |    Parasolid     |            .x_b, .x_t, .xmt, .xmt_txt            |                    Up to 35.1                    |
 |      Revit       |                       .rvt                       |                    2015-2023                     |


### PR DESCRIPTION
Reverts Vertexvis/dev-portal#64 due to rolling back changes in our translation system.