### PR TITLE
[PLAT-4042] Document CONNECT_WORKSPACE_URN option

### DIFF
--- a/docs/guides/import-data-with-api.mdx
+++ b/docs/guides/import-data-with-api.mdx
@@ -254,3 +254,15 @@ curl --location --request GET \
 
 </TabItem>
 </Tabs>
+
+:::tip
+Data contained in scenes that are created or updated with the metadata key/value pair `"CONNECT_WORKSPACE_URN": "{YOUR_URN}"` will be added to the corresponding Connect workspace. This information can be added to the attributes section of your requests to create or update a scene:
+```
+    "attributes": {
+      "metadata": {
+        "CONNECT_WORKSPACE_URN": "{YOUR_URN}"
+      }
+    }
+```
+To learn more about scenes in Vertex, see [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes).
+:::

--- a/docs/guides/render-static-scenes.mdx
+++ b/docs/guides/render-static-scenes.mdx
@@ -97,17 +97,6 @@ curl --location --request POST \
 </TabItem>
 </Tabs>
 
-:::tip
-Scenes that are created or updated with the metadata key/value pair `"CONNECT_WORKSPACE_URN": "{YOUR_URN}"` will be added to the corresponding Connect workspace. This information can be added to the attributes section of your requests:
-```
-    "attributes": {
-      "metadata": {
-        "CONNECT_WORKSPACE_URN": "{YOUR_URN}"
-      }
-    }
-```
-:::
-
 Now that the scene resource exists, `POST` to the [createSceneItem](https://docs.vertexvis.com/#d597f539-3785-4c83-a645-fdf3a9a90521) API. This API is asynchronous, returning the status of a queued scene item. See the [Transformation matrices](./transformation-matrices.mdx) reference for an explanation of the `transform` property.
 
 <Tabs

--- a/docs/guides/render-static-scenes.mdx
+++ b/docs/guides/render-static-scenes.mdx
@@ -102,9 +102,9 @@ Scenes that are created or updated with the metadata key/value pair `"CONNECT_WO
 ```
     "attributes": {
       "metadata": {
-        "CONNECT_WORKSPACE_URN": "{YOUR_URN}",
-      },
-    },
+        "CONNECT_WORKSPACE_URN": "{YOUR_URN}"
+      }
+    }
 ```
 :::
 

--- a/docs/guides/render-static-scenes.mdx
+++ b/docs/guides/render-static-scenes.mdx
@@ -97,6 +97,17 @@ curl --location --request POST \
 </TabItem>
 </Tabs>
 
+:::tip
+Scenes that are created or updated with the metadata key/value pair `"CONNECT_WORKSPACE_URN": "{YOUR_URN}"` will be added to the corresponding Connect workspace. This information can be added to the attributes section of your requests:
+```
+    "attributes": {
+      "metadata": {
+        "CONNECT_WORKSPACE_URN": "{YOUR_URN}",
+      },
+    },
+```
+:::
+
 Now that the scene resource exists, `POST` to the [createSceneItem](https://docs.vertexvis.com/#d597f539-3785-4c83-a645-fdf3a9a90521) API. This API is asynchronous, returning the status of a queued scene item. See the [Transformation matrices](./transformation-matrices.mdx) reference for an explanation of the `transform` property.
 
 <Tabs


### PR DESCRIPTION
## Summary
This PR updates the documentation to include information on how to set CONNECT_WORKSPACE_URN in order to automatically push data to a specific location in Connect.