### PR TITLE
vertexvis.com to vertex3d.com

### DIFF
--- a/docs/guides/authentication.mdx
+++ b/docs/guides/authentication.mdx
@@ -42,7 +42,7 @@ The flow is as follows:
 
 ## Creating access tokens
 
-To create an access token, `POST` to the [createToken](https://docs.vertexvis.com/#f8c5dc19-0f68-442e-8d28-aa03be2c48fb) API with your credentials. The token API uses HTTP basic access authentication. The request contains the `Authorization: Basic [YOUR_CREDENTIALS]` header, where `YOUR_CREDENTIALS` is the Base64 encoding of your Vertex client ID and secret joined by a colon. The following command performs this encoding and creates an access token.
+To create an access token, `POST` to the [createToken](https://docs.vertex3d.com/#f8c5dc19-0f68-442e-8d28-aa03be2c48fb) API with your credentials. The token API uses HTTP basic access authentication. The request contains the `Authorization: Basic [YOUR_CREDENTIALS]` header, where `YOUR_CREDENTIALS` is the Base64 encoding of your Vertex client ID and secret joined by a colon. The following command performs this encoding and creates an access token.
 
 :::note
 
@@ -97,7 +97,7 @@ curl --location --request GET \
 
 ## Viewer component
 
-The Viewer component authenticates using stream keys. These keys grant access to specific scenes, so you'll need one first. If you don't have one, create one by following the [Import data](./import-data.mdx) and [Render static scenes](./render-static-scenes.mdx) guides. Then, to create a stream key, `POST` to the [createSceneStreamKey](https://docs.vertexvis.com/#dd9c119e-5808-4bc5-8aeb-afc1ca34362d) API.
+The Viewer component authenticates using stream keys. These keys grant access to specific scenes, so you'll need one first. If you don't have one, create one by following the [Import data](./import-data.mdx) and [Render static scenes](./render-static-scenes.mdx) guides. Then, to create a stream key, `POST` to the [createSceneStreamKey](https://docs.vertex3d.com/#dd9c119e-5808-4bc5-8aeb-afc1ca34362d) API.
 
 <Tabs
   defaultValue="req"

--- a/docs/guides/import-data-with-api.mdx
+++ b/docs/guides/import-data-with-api.mdx
@@ -38,7 +38,7 @@ To import your 3D data into the Parts Library, do the following:
 
 ## Uploading files
 
-See our [supported file formats](./supported-file-formats.mdx). If you do not have 3D data handy, download a model from our [3D database](./model-database.mdx) to follow along. To create files in one of these formats, `POST` to the [createFile](https://docs.vertexvis.com/#a8f05429-036c-45b8-89ef-6bd3aa14a7fe) API.
+See our [supported file formats](./supported-file-formats.mdx). If you do not have 3D data handy, download a model from our [3D database](./model-database.mdx) to follow along. To create files in one of these formats, `POST` to the [createFile](https://docs.vertex3d.com/#a8f05429-036c-45b8-89ef-6bd3aa14a7fe) API.
 
 :::note
 
@@ -92,7 +92,7 @@ curl --location --request POST \
 </TabItem>
 </Tabs>
 
-Now that the file resource exists, `POST` to the [uploadFile](https://docs.vertexvis.com/#0b0a01c2-831d-4b01-87ea-765d4f2e6c1a) API.
+Now that the file resource exists, `POST` to the [uploadFile](https://docs.vertex3d.com/#0b0a01c2-831d-4b01-87ea-765d4f2e6c1a) API.
 
 <Tabs
   defaultValue="req"
@@ -122,7 +122,7 @@ curl --location --request POST \
 
 ## Creating parts
 
-To make querying for parts easier, Vertex supports supplied IDs. You supply these IDs, likely using existing part and revision IDs from your PLM system. To initiate translations, `POST` to the [createPart](https://docs.vertexvis.com/#05c13b3e-b407-4b19-b110-e6bdc016a714) API. This API is asynchronous, returning the status of a queued translation.
+To make querying for parts easier, Vertex supports supplied IDs. You supply these IDs, likely using existing part and revision IDs from your PLM system. To initiate translations, `POST` to the [createPart](https://docs.vertex3d.com/#05c13b3e-b407-4b19-b110-e6bdc016a714) API. This API is asynchronous, returning the status of a queued translation.
 
 <Tabs
   defaultValue="req"
@@ -179,14 +179,14 @@ curl --location --request POST \
 </TabItem>
 </Tabs>
 
-To check the status of queued translations, `GET` the [getQueuedTranslation](https://docs.vertexvis.com/#9d4734b1-3300-46bb-bb87-85d23b5e52a3) API. The response returns one of the following:
+To check the status of queued translations, `GET` the [getQueuedTranslation](https://docs.vertex3d.com/#9d4734b1-3300-46bb-bb87-85d23b5e52a3) API. The response returns one of the following:
 
 - The status if `running`.
 - An `error` (similar to the response above).
 - Upon completion, redirects to the created part.
 
 :::note
-The `PART_ID` returned is for the root assembly or part. If your file contains a hierarchy, query for other parts using the [getParts](https://docs.vertexvis.com/#25778d06-038f-410f-bb67-503c932a59a8) API.
+The `PART_ID` returned is for the root assembly or part. If your file contains a hierarchy, query for other parts using the [getParts](https://docs.vertex3d.com/#25778d06-038f-410f-bb67-503c932a59a8) API.
 :::
 
 <Tabs
@@ -264,5 +264,5 @@ Data contained in scenes that are created or updated with the metadata key/value
       }
     }
 ```
-To learn more about scenes in Vertex, see [Render static scenes](https://developer.vertexvis.com/docs/guides/render-static-scenes).
+To learn more about scenes in Vertex, see [Render static scenes](https://developer.vertex3d.com/docs/guides/render-static-scenes).
 :::

--- a/docs/guides/import-metadata.mdx
+++ b/docs/guides/import-metadata.mdx
@@ -32,7 +32,7 @@ While [creating parts](./import-data.mdx#creating-parts), set the `indexMetadata
 
 ## Adding to existing part revisions
 
-To add metadata to existing part revisions, `PATCH` the [updatePartRevision](https://docs.vertexvis.com/#4dc8ffa1-c138-476f-ba9b-d3f1ca382223) API.
+To add metadata to existing part revisions, `PATCH` the [updatePartRevision](https://docs.vertex3d.com/#4dc8ffa1-c138-476f-ba9b-d3f1ca382223) API.
 
 <Tabs
   defaultValue="req"
@@ -139,7 +139,7 @@ java.time.Instant.now().toString();
 
 ## Getting metadata
 
-To get metadata for a part revisions, `GET` the [getPartRevision](https://docs.vertexvis.com/#3260f3e6-8264-4c44-b41d-595a4c37f14a) API. By default, the response does not include metadata. You must explicitly request it using the `fields[part-revision]=metadata` query parameter.
+To get metadata for a part revisions, `GET` the [getPartRevision](https://docs.vertex3d.com/#3260f3e6-8264-4c44-b41d-595a4c37f14a) API. By default, the response does not include metadata. You must explicitly request it using the `fields[part-revision]=metadata` query parameter.
 
 :::note
 

--- a/docs/guides/postman-quick-start.mdx
+++ b/docs/guides/postman-quick-start.mdx
@@ -15,7 +15,7 @@ For advanced functionality beyond what our UI Components provide, you can option
 ## Open Vertex's Postman collection
 
 1. [Download and install Postman](https://www.postman.com/downloads/).
-2. In the upper-right corner of our [API Reference](https://docs.vertexvis.com/) documentation, click **Run in Postman**.
+2. In the upper-right corner of our [API Reference](https://docs.vertex3d.com/) documentation, click **Run in Postman**.
 
 The collection contains the reference documentation as well, as shown below.
 

--- a/docs/guides/render-static-scenes.mdx
+++ b/docs/guides/render-static-scenes.mdx
@@ -48,7 +48,7 @@ To create and view scenes, do the following:
 
 ## Creating scenes and scene items
 
-To create scenes, `POST` to the [createScene](https://docs.vertexvis.com/#fe3357f4-c86d-49d2-832a-e76f1f386cc3) API.
+To create scenes, `POST` to the [createScene](https://docs.vertex3d.com/#fe3357f4-c86d-49d2-832a-e76f1f386cc3) API.
 
 <Tabs
   defaultValue="req"
@@ -97,7 +97,7 @@ curl --location --request POST \
 </TabItem>
 </Tabs>
 
-Now that the scene resource exists, `POST` to the [createSceneItem](https://docs.vertexvis.com/#d597f539-3785-4c83-a645-fdf3a9a90521) API. This API is asynchronous, returning the status of a queued scene item. See the [Transformation matrices](./transformation-matrices.mdx) reference for an explanation of the `transform` property.
+Now that the scene resource exists, `POST` to the [createSceneItem](https://docs.vertex3d.com/#d597f539-3785-4c83-a645-fdf3a9a90521) API. This API is asynchronous, returning the status of a queued scene item. See the [Transformation matrices](./transformation-matrices.mdx) reference for an explanation of the `transform` property.
 
 <Tabs
   defaultValue="req"
@@ -160,7 +160,7 @@ curl --location --request POST \
 </TabItem>
 </Tabs>
 
-To check the status of queued scene items, `GET` the [getQueuedSceneItem](https://docs.vertexvis.com/#f11ab42d-fda6-432c-b219-f7f59299c2eb) API. The response returns one of the following:
+To check the status of queued scene items, `GET` the [getQueuedSceneItem](https://docs.vertex3d.com/#f11ab42d-fda6-432c-b219-f7f59299c2eb) API. The response returns one of the following:
 
 - The status if `running`.
 - An `error` (similar to the response above).
@@ -217,7 +217,7 @@ curl --location --request GET \
 </TabItem>
 </Tabs>
 
-Now that the scene contains scene items, commit it with a `PATCH` to the [updateScene](https://docs.vertexvis.com/#5fa99d4f-85d6-451d-abda-e0459830daf4) API.
+Now that the scene contains scene items, commit it with a `PATCH` to the [updateScene](https://docs.vertex3d.com/#5fa99d4f-85d6-451d-abda-e0459830daf4) API.
 
 <Tabs
   defaultValue="req"
@@ -274,12 +274,12 @@ curl --location --request PATCH \
 View scenes either by getting a scene image from the API or using the Viewer component.
 
 :::note
-If you do not see any items in your scene, make sure the scene is in the `commit` state. If it is, try updating the camera with the [updateScene](https://docs.vertexvis.com/#5fa99d4f-85d6-451d-abda-e0459830daf4) API.
+If you do not see any items in your scene, make sure the scene is in the `commit` state. If it is, try updating the camera with the [updateScene](https://docs.vertex3d.com/#5fa99d4f-85d6-451d-abda-e0459830daf4) API.
 :::
 
 ### In the API
 
-To get a scene image, `GET` the [renderScene](https://docs.vertexvis.com/#defdc52f-a574-4f65-92f9-d59bba85ca1a) API.
+To get a scene image, `GET` the [renderScene](https://docs.vertex3d.com/#defdc52f-a574-4f65-92f9-d59bba85ca1a) API.
 
 <Tabs
   defaultValue="req"

--- a/docs/guides/webhooks.mdx
+++ b/docs/guides/webhooks.mdx
@@ -66,7 +66,7 @@ With the CLI, run the following command.
 vertex webhook-subscriptions:create --url https://example.com --topics scene.update
 ```
 
-With the API, `POST` to the [createWebhookSubscription](https://docs.vertexvis.com/#27c642fc-6abd-4fea-851b-7f7b5cc476cb) API. [See the table below](#topics) for available topics. It's best practice to receive only the topics required by your application. Listening for extra events puts strain on your server and is not recommended.
+With the API, `POST` to the [createWebhookSubscription](https://docs.vertex3d.com/#27c642fc-6abd-4fea-851b-7f7b5cc476cb) API. [See the table below](#topics) for available topics. It's best practice to receive only the topics required by your application. Listening for extra events puts strain on your server and is not recommended.
 
 <Tabs
   defaultValue="req"

--- a/docs/sdks-and-tools.mdx
+++ b/docs/sdks-and-tools.mdx
@@ -23,7 +23,7 @@ The following tools simplify and accelerate the development of applications leve
 | Java    | [GitHub](https://github.com/Vertexvis/vertex-api-client-java)                | [![Maven](https://img.shields.io/maven-central/v/com.vertexvis/api-client-java)](https://search.maven.org/artifact/com.vertexvis/api-client-java)        |                                                                |
 | C#      | [Coming soon!](https://github.com/Vertexvis/vertex-community/discussions/22) |                                                                                                                                                          |                                                                |
 
-If you use a different language, either [let us know](/contact), use the [`openapi-generator`](https://github.com/OpenAPITools/openapi-generator) to generate a client, or follow the [API Reference](https://docs.vertexvis.com/) and use the framework of your choice.
+If you use a different language, either [let us know](/contact), use the [`openapi-generator`](https://github.com/OpenAPITools/openapi-generator) to generate a client, or follow the [API Reference](https://docs.vertex3d.com/) and use the framework of your choice.
 
 ## Starter projects
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -4,7 +4,7 @@ module.exports = {
   title: '3D Visualization Engine',
   tagline:
     "Easily integrate 3D product data into your business applications using Vertex's distributed cloud rendering system.",
-  url: 'https://developer.vertexvis.com',
+  url: 'https://developer.vertex3d.com',
   baseUrl: '/',
   favicon: 'img/favicon-512x512.png',
   organizationName: 'Vertexvis',
@@ -73,7 +73,7 @@ module.exports = {
           position: 'right',
         },
         {
-          href: 'https://docs.vertexvis.com/',
+          href: 'https://docs.vertex3d.com/',
           label: 'API Reference',
           position: 'right',
         },
@@ -126,7 +126,7 @@ module.exports = {
             },
             {
               label: 'API Reference',
-              to: 'https://docs.vertexvis.com/',
+              to: 'https://docs.vertex3d.com/',
             },
             {
               label: 'Support',

--- a/src/components/CodeExamples.js
+++ b/src/components/CodeExamples.js
@@ -124,7 +124,7 @@ export function Viewer({ src }) {
   });
 
   return (
-    <BrowserWindow url="developer.vertexvis.com">
+    <BrowserWindow url="developer.vertex3d.com">
       <iframe
         ref={ref}
         width="100%"

--- a/src/components/ExampleAppNote.js
+++ b/src/components/ExampleAppNote.js
@@ -15,7 +15,7 @@ export function ExampleAppNote() {
         </li>
         <li>
           You are familiar with the raycaster tool and hit results for{' '}
-          <Link href="https://developer.vertexvis.com/docs/guides/render-your-first-scene#interact-with-the-scene">
+          <Link href="https://developer.vertex3d.com/docs/guides/render-your-first-scene#interact-with-the-scene">
             interacting with the scene
           </Link>
           .

--- a/src/pages/api/1.0.js
+++ b/src/pages/api/1.0.js
@@ -15,7 +15,7 @@ const Api = ({ version }) => {
       <div style={{ marginTop: `5rem`, textAlign: 'center' }}>
         <p>
           Our 1.0 API Reference has{' '}
-          <a href="https://docs.vertexvis.com/">moved here</a>.
+          <a href="https://docs.vertex3d.com/">moved here</a>.
         </p>
       </div>
     </Layout>

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,1 +1,1 @@
-developer.vertexvis.com
+developer.vertex3d.com


### PR DESCRIPTION
Moving developer.vertexvis.com and docs.vertexvis.com to vertex3d.com.  

Corresponding changes will need to be made in Github and Postman as well as Route53 to support this change.  