### PR TITLE
[PLAT-4506] Using JSDelivr instead of Unpkg

### DIFF
--- a/docs/guides/install-sdk.mdx
+++ b/docs/guides/install-sdk.mdx
@@ -79,17 +79,17 @@ The UI Components can be used without any build system, either by uploading file
     <meta charset="utf-8" />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer/viewer.css"
     />
   </head>
   <body>
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer.js"
     ></script>
   </body>
 </html>

--- a/docs/guides/render-your-first-scene.mdx
+++ b/docs/guides/render-your-first-scene.mdx
@@ -30,7 +30,7 @@ Save the following HTML to a file on your computer and open it in your browser. 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer/viewer.css"
     />
     <style>
       html,
@@ -46,11 +46,11 @@ Save the following HTML to a file on your computer and open it in your browser. 
   <body>
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer.js"
     ></script>
 
     <vertex-viewer
@@ -71,8 +71,8 @@ Save the following HTML to a file on your computer and open it in your browser. 
 To render a scene, you'll need a stream key. Stream keys grant the Viewer component access to a specific scene. This is explained in more detail later, but for now, use our test key, `AH7v0jg5aN5_thkhU-XTzB_29aqW89EjyOH8`. Copy the following into the empty `<script>` tag.
 
 ```js
-import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@0.17.x/dist/esm/loader.js';
-import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.17.x/dist/esm/index.js';
+import { defineCustomElements } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/esm/loader.js';
+import { ColorMaterial } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/esm/index.js';
 
 async function main() {
   await defineCustomElements(window);

--- a/static/examples/first-scene/index.html
+++ b/static/examples/first-scene/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer/viewer.css"
     />
     <style>
       html,
@@ -22,11 +22,11 @@
   <body>
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer.js"
     ></script>
 
     <vertex-viewer
@@ -36,8 +36,8 @@
     </vertex-viewer>
 
     <script type="module">
-      import { defineCustomElements } from 'https://unpkg.com/@vertexvis/viewer@0.17.x/dist/esm/loader.js';
-      import { ColorMaterial } from 'https://unpkg.com/@vertexvis/viewer@0.17.x/dist/esm/index.js';
+      import { defineCustomElements } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/esm/loader.js';
+      import { ColorMaterial } from 'https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/esm/index.js';
 
       async function main() {
         await defineCustomElements(window);

--- a/static/examples/load-model/configure-scene.html
+++ b/static/examples/load-model/configure-scene.html
@@ -2,15 +2,15 @@
   <head>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer.js"
     ></script>
 
     <link rel="stylesheet" href="../viewer.css" />

--- a/static/examples/load-model/create-scene.html
+++ b/static/examples/load-model/create-scene.html
@@ -2,15 +2,15 @@
   <head>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer.js"
     ></script>
 
     <link rel="stylesheet" href="../viewer.css" />

--- a/static/examples/loading-model/index.html
+++ b/static/examples/loading-model/index.html
@@ -3,15 +3,15 @@
     <meta charset="utf-8" />
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@0.17.x/dist/viewer.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.17.x/dist/viewer.js"
     ></script>
   </head>
   <body>

--- a/static/examples/scene-operations/overview.html
+++ b/static/examples/scene-operations/overview.html
@@ -2,15 +2,15 @@
   <head>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer.js"
     ></script>
 
     <link rel="stylesheet" type="text/css" href="../viewer.css" />

--- a/versioned_docs/version-beta/sdk/sdk-web-getting-started.md
+++ b/versioned_docs/version-beta/sdk/sdk-web-getting-started.md
@@ -20,15 +20,15 @@ The easiest way to pull the viewer component into your project is to include the
   <head>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@0.3.x/dist/viewer.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.x/dist/viewer.js"
     ></script>
   </head>
 </html>
@@ -51,15 +51,15 @@ Here's a simple example of loading a model:
   <head>
     <link
       rel="stylesheet"
-      href="https://unpkg.com/@vertexvis/viewer@0.3.2-5/dist/viewer/viewer.css"
+      href="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.2-5/dist/viewer/viewer.css"
     />
     <script
       type="module"
-      src="https://unpkg.com/@vertexvis/viewer@0.3.2-5/dist/viewer/viewer.esm.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.2-5/dist/viewer/viewer.esm.js"
     ></script>
     <script
       nomodule
-      src="https://unpkg.com/@vertexvis/viewer@0.3.2-5/dist/viewer.js"
+      src="https://cdn.jsdelivr.net/npm/@vertexvis/viewer@0.3.2-5/dist/viewer.js"
     ></script>
 
     <script>


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->
Modifies all of the cdn packages to use Js deliver instead of unpkg. I did do some smoke testing with these and these assets do appear to load a lot faster than unpkg.

## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
