### PR TITLE
[PLAT-8078] Webhook topics update to include threads & reply hooks

### DIFF
--- a/docs/guides/collaboration-apis.mdx
+++ b/docs/guides/collaboration-apis.mdx
@@ -81,7 +81,7 @@ of the Collaboration APIs.
 
 | Operation               | Endpoint                                           | Auth       |
 | ----------------------- | -------------------------------------------------- | ---------- |
-| Create a thread         | `POST /threads`                                    | User token |
+| Create a thread         | `POST /collaboration-contexts/{id}/threads`        | User token |
 | List threads by context | `GET /threads?filter[collaborationContextId]={id}` | User token |
 | Get thread by ID        | `GET /threads/{id}`                                | User token |
 | Update a thread         | `PATCH /threads/{id}`                              | User token |
@@ -91,7 +91,7 @@ of the Collaboration APIs.
 
 | Operation              | Endpoint                             | Auth       |
 | ---------------------- | ------------------------------------ | ---------- |
-| Create a reply         | `POST /replies`                      | User token |
+| Create a reply         | `POST /threads/{}/replies`           | User token |
 | List replies in thread | `GET /replies?filter[threadId]={id}` | User token |
 | Get reply by ID        | `GET /replies/{id}`                  | User token |
 | Update a reply         | `PATCH /replies/{id}`                | User token |

--- a/docs/guides/webhooks.mdx
+++ b/docs/guides/webhooks.mdx
@@ -297,95 +297,80 @@ Occurs when a Part Revision is updated using the `PATCH /part-revisions/:id` end
 
 Occurs when a Thread is created using the `POST /collaboration-contexts/:id/threads` endpoint.
 
-<br />
-
 - `included` for this event can contain the following resources:
   - `self` will always be included and references the Thread.
     - This resource will include the `body_document`, `title`, `status`, `is_drafting` for this thread.
-  - `collaborationContextId` will be included with the Thread
-  - `bodyText` will also be included, which is a textual representation of document of the thread. 
+  - `collaborationContextId` will be included with the Thread.
+  - `bodyText` will also be included, which is a textual representation of the document of the thread. 
   - `mentions` will be included as an array of users mentioned within the document of the thread. 
-<br />
 
 #### `thread.updated`
 
 Occurs when a Thread is updated using the `PATCH /threads/:id` endpoint.
 
 - `data.attributes.changed` for this event can contain the following properties:
-  - `with_body` if the document of the thread changed
-  - `title` if the title of the thread changed
-  - `status` if the status of the thread changed
-  - `is_drafting` if the drafting state of the thread changed
+  - `with_body` if the document of the thread changed.
+  - `title` if the title of the thread changed.
+  - `status` if the status of the thread changed.
+  - `is_drafting` if the drafting state of the thread changed.
 
-<br />
 
 - `included` for this event can contain the following resources:
   - `self` will always be included and references the Thread.
     - This resource will include the `body_document`, `title`, `status`, `is_drafting` for this thread.
-  - `collaborationContextId` will be included with the Thread
-  - `bodyText` will also be included, which is a textual representation of document of the thread. 
+  - `collaborationContextId` will be included with the Thread.
+  - `bodyText` will also be included, which is a textual representation of the document of the thread. 
   - `mentions` will be included as an array of users mentioned within the document of the thread. 
-<br />
 
 #### `thread.deleted`
 
 Occurs when a Thread is deleted using the `DELETE /threads/:id` endpoint.
 
-<br />
-
 - `included` for this event can contain the following resources:
   - `self` will always be included and references the Thread.
     - This resource will include the `body_document`, `title`, `status`, `is_drafting` for this thread.
-  - `collaborationContextId` will be included with the Thread
-<br />
+  - `collaborationContextId` will be included with the Thread.
 
 
 #### `reply.created`
 
 Occurs when a Reply is created using the `POST /threads/:id/replies` endpoint.
 
-<br />
 
 - `included` for this event can contain the following resources:
   - `self` will always be included and references the Reply.
     - This resource will include the `body_document` and `is_drafting` for this reply.
-  - `collaborationContextId` will be included with the Reply
-  - `threadId` will be included with the Reply
+  - `collaborationContextId` will be included with the Reply.
+  - `threadId` will be included with the Reply.
   - `bodyText` will also be included, which is a textual representation of document of the reply. 
   - `mentions` will be included as an array of users mentioned within the document of the reply. 
-<br />
 
 #### `reply.updated`
 
 Occurs when a Reply is updated using the `PATCH /replies/:id` endpoint.
 
 - `data.attributes.changed` for this event can contain the following properties:
-  - `with_body` if the document of the reply changed
-  - `is_drafting` if the drafting state of the reply changed
-
-<br />
+  - `with_body` if the document of the reply changed.
+  - `is_drafting` if the drafting state of the reply changed.
 
 - `included` for this event can contain the following resources:
   - `self` will always be included and references the Reply.
     - This resource will include the `body_document` and `is_drafting` for this reply.
-  - `collaborationContextId` will be included with the Reply
-  - `threadId` will be included with the Reply
+  - `collaborationContextId` will be included with the Reply.
+  - `threadId` will be included with the Reply.
   - `bodyText` will also be included, which is a textual representation of document of the reply. 
   - `mentions` will be included as an array of users mentioned within the document of the reply. 
-<br />
 
 #### `reply.deleted`
 
 Occurs when a Reply is deleted using the `DELETE /replies/:id` endpoint.
 
-<br />
 
 - `included` for this event can contain the following resources:
   - `self` will always be included and references the Reply.
     - This resource will include the `body_document` and `is_drafting` for this reply.
-  - `collaborationContextId` will be included with the Reply
-  - `threadId` will be included with the Reply
-<br />
+  - `collaborationContextId` will be included with the Reply.
+  - `threadId` will be included with the Reply.
 
 
 ## Retry schedule

--- a/docs/guides/webhooks.mdx
+++ b/docs/guides/webhooks.mdx
@@ -293,6 +293,101 @@ Occurs when a Part Revision is updated using the `PATCH /part-revisions/:id` end
   - `part` will be included if the Part Revision references a Part.
   - `defaultPartRendition` will be included if the Part Revision has a default Part Rendition.
 
+#### `thread.created`
+
+Occurs when a Thread is created using the `POST /collaboration-contexts/:id/threads` endpoint.
+
+<br />
+
+- `included` for this event can contain the following resources:
+  - `self` will always be included and references the Thread.
+    - This resource will include the `body_document`, `title`, `status`, `is_drafting` for this thread.
+  - `collaborationContextId` will be included with the Thread
+  - `bodyText` will also be included, which is a textual representation of document of the thread. 
+  - `mentions` will be included as an array of users mentioned within the document of the thread. 
+<br />
+
+#### `thread.updated`
+
+Occurs when a Thread is updated using the `PATCH /threads/:id` endpoint.
+
+- `data.attributes.changed` for this event can contain the following properties:
+  - `with_body` if the document of the thread changed
+  - `title` if the title of the thread changed
+  - `status` if the status of the thread changed
+  - `is_drafting` if the drafting state of the thread changed
+
+<br />
+
+- `included` for this event can contain the following resources:
+  - `self` will always be included and references the Thread.
+    - This resource will include the `body_document`, `title`, `status`, `is_drafting` for this thread.
+  - `collaborationContextId` will be included with the Thread
+  - `bodyText` will also be included, which is a textual representation of document of the thread. 
+  - `mentions` will be included as an array of users mentioned within the document of the thread. 
+<br />
+
+#### `thread.deleted`
+
+Occurs when a Thread is deleted using the `DELETE /threads/:id` endpoint.
+
+<br />
+
+- `included` for this event can contain the following resources:
+  - `self` will always be included and references the Thread.
+    - This resource will include the `body_document`, `title`, `status`, `is_drafting` for this thread.
+  - `collaborationContextId` will be included with the Thread
+<br />
+
+
+#### `reply.created`
+
+Occurs when a Reply is created using the `POST /threads/:id/replies` endpoint.
+
+<br />
+
+- `included` for this event can contain the following resources:
+  - `self` will always be included and references the Reply.
+    - This resource will include the `body_document` and `is_drafting` for this reply.
+  - `collaborationContextId` will be included with the Reply
+  - `threadId` will be included with the Reply
+  - `bodyText` will also be included, which is a textual representation of document of the reply. 
+  - `mentions` will be included as an array of users mentioned within the document of the reply. 
+<br />
+
+#### `reply.updated`
+
+Occurs when a Reply is updated using the `PATCH /replies/:id` endpoint.
+
+- `data.attributes.changed` for this event can contain the following properties:
+  - `with_body` if the document of the reply changed
+  - `is_drafting` if the drafting state of the reply changed
+
+<br />
+
+- `included` for this event can contain the following resources:
+  - `self` will always be included and references the Reply.
+    - This resource will include the `body_document` and `is_drafting` for this reply.
+  - `collaborationContextId` will be included with the Reply
+  - `threadId` will be included with the Reply
+  - `bodyText` will also be included, which is a textual representation of document of the reply. 
+  - `mentions` will be included as an array of users mentioned within the document of the reply. 
+<br />
+
+#### `reply.deleted`
+
+Occurs when a Reply is deleted using the `DELETE /replies/:id` endpoint.
+
+<br />
+
+- `included` for this event can contain the following resources:
+  - `self` will always be included and references the Reply.
+    - This resource will include the `body_document` and `is_drafting` for this reply.
+  - `collaborationContextId` will be included with the Reply
+  - `threadId` will be included with the Reply
+<br />
+
+
 ## Retry schedule
 
 | Retry number | Interval relative to last retry | Approx Time relative to original attempt |


### PR DESCRIPTION
## Summary
<!-- Implementation and architectural changes introduced. -->

These changes document the webhook fields for `reply.created`, `reply.updated`, `reply.deleted`, `thread.created`, `thread.updated`, and `thread.deleted`. 

Here is a video of the visual changes to add these recently added webhook topics:

https://github.com/user-attachments/assets/44453878-3665-40c5-b758-f8b4a6232745



## Test Plan
<!-- How to test changes. -->

## Release Notes
<!-- Provided to customers. Explain new features, bug fixes, and deprecating or breaking changes. -->

## Possible Regressions
<!-- Possible impacts to other features. -->

## Dependencies
<!-- Links to dependent PRs or tickets. -->
