### PR TITLE
Update browser compatibility doc page

### DIFF
--- a/docs/guides/browser-compatibility.mdx
+++ b/docs/guides/browser-compatibility.mdx
@@ -4,11 +4,11 @@ title: Browser compatibility
 description: Browser compatibility for the Vertex platform's Web UI Components.
 ---
 
-Our web components should work with most modern browsers, including those that support the [Custom Elements v1 specification](https://developers.google.com/web/fundamentals/web-components/customelements). For many browsers without Custom Elements v1 support, we automatically use polyfills. We support both mouse and touch interactions out of the box.
+Our web components should work with most modern browsers, including those that support the [Custom Elements v1 specification](https://developers.google.com/web/fundamentals/web-components/customelements). We support both mouse and touch interactions out of the box.
 
-| Edge | Chrome\* | Firefox\* | Safari 9+\* | Chrome Android\* | Mobile Safari\* |
-| :--: | :------: | :-------: | :---------: | :--------------: | :-------------: |
-|  ✓   |    ✓     |     ✓     |      ✓      |        ✓         |        ✓        |
+| Edge\* | Chrome\* | Firefox\* | Safari\* | Chrome Android\* | Mobile Safari\* |
+| :----: | :------: | :-------: | :------: | :--------------: | :-------------: |
+|   ✓    |    ✓     |     ✓     |     ✓    |        ✓         |        ✓        |
 
 \*Indicates the current version of the browser
 


### PR DESCRIPTION
## Summary

Polyfills will no longer be automatically included in web-sdk as of 1.0

And mild updates to browser support matrix to reflect modern browser versions
